### PR TITLE
s.cep cannot advance because r.cep did not

### DIFF
--- a/draft-ietf-tcpm-accurate-ecn-10.xml
+++ b/draft-ietf-tcpm-accurate-ecn-10.xml
@@ -1283,7 +1283,7 @@ deliberately to reduce complexity.-->
 
             <c>CE</c>
 
-            <c>6</c>
+            <c>5</c>
 
             <c>0b111</c>
 


### PR DESCRIPTION
This is a leftover from the always init to 5 change. Instead of this, you may choose to just remove that column and move "Disable ECN" from the first row into other column.

As r.cep is now always initialized to 5, s.cep should also.
Otherwise d.cep will report a false delta (congestion) right from
the beginning.

Perhaps, it would be better to just remove the whole s.cep
init column but this simple change at least fixes the existing
problem.